### PR TITLE
Added some basic metadata to the head

### DIFF
--- a/src/components/hero-title/index.marko
+++ b/src/components/hero-title/index.marko
@@ -1,6 +1,6 @@
 style {
   .wrapper {
-    background: #3366ff;
+    background: #3366FF;
     height: 100%;
     padding: calc(1vh + 1vw);
   }

--- a/src/components/site-layout/index.marko
+++ b/src/components/site-layout/index.marko
@@ -3,7 +3,12 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width">
-    <title><include(input.title)/></title>
+    <meta name="theme-color" content="#3366FF" />
+    <meta name="author" content="Jon Short">
+    <meta name="description" content="CSS property position: sticky is another css property that makes complex, responsive layouts easy.">
+    <meta property="og:description" content="CSS property position: sticky is another css property that makes complex, responsive layouts easy.">
+    <meta property="og:title" content="Sticky POC">
+    <title>Sticky POC</title>
   </head>
   <body>
     <include(input.content)/>

--- a/src/index.marko
+++ b/src/index.marko
@@ -1,5 +1,4 @@
 site-layout
-  @title -- Sticky POC
   @content
     hero-title
       @title -- StickyPOC


### PR DESCRIPTION
### Metadata additions
- Theme colour: Colour for the address bar in mobile chrome
- Author: name of author
- Description: brief description of the site
- OG Description: same as the regular description (at the moment) - for rich links
- OG Title: same as the regular title (at the moment) - for rich links